### PR TITLE
feat: init charter

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -131,7 +131,7 @@ TSC Chairperson or voting CPC member may serve.
 
 #### Section 4.2.2. Decision Making
 
-For internal project decisions, Collaborators shall operate under Lazy Consensus. The TSC voting members shall establish 
+For webpack projects' decisions, Collaborators shall operate under Lazy Consensus. The TSC voting members shall establish 
 appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods) within the 
 development process.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -156,7 +156,7 @@ Modifications of the contents of the git repository are made on a collaborative 
 process.
 
 Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found 
-consensus to the TSC for discussion by assigning the `tsc-agenda` tag to a pull request or issue. The TSC voting members 
+consensus to the TSC for discussion. The TSC voting members 
 should serve as the final arbiter where required. The TSC will maintain and publish a list of current Collaborators, as 
 well as a development process guide for Collaborators and Contributors looking to participate in the development effort.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -145,7 +145,7 @@ choose to participate in any vote through abstention.
 
 All changes to this charter must be approved by the CPC.
 
-#### Section 4.2.3. Project Roles
+#### Section 4.3. Other Project Roles
 
 The webpack git repository is maintained by the TSC and additional Collaborators who are added by the TSC voting members 
 on an ongoing basis.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -50,6 +50,13 @@ and improve applications.
 
 These projects, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib`.
 
+### 1.2: Out-of-Scope
+
+- Testing frameworks (e.g., unit, integration, or end-to-end testing tools)
+- API development and handling
+- Server-side rendering directly (although it can integrate with SSR frameworks)
+- Frameworks and libraries that operate in their own capacity.
+
 ## Section 2. Relationship with OpenJS Foundation CPC.
 
 Most large, complex open source communities have both a business and a technical governance model. Technical leadership 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -163,7 +163,7 @@ well as a development process guide for Collaborators and Contributors looking t
 
 * **Contributors**: contribute code or other artifacts, but do not have the right to commit to the code base. 
   Contributors work with the project's Collaborators to have code committed to the code base. A Contributor may be 
-  promoted to a Collaborator by the TSC. Contributors should rarely be encumbered by the TSC and never by the CPC or 
+  promoted to a Collaborator by the TSC. Contributors should rarely be blocked by the TSC and never by the CPC or 
   OpenJS Foundation Board.
 
 * **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the project creation 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -129,7 +129,7 @@ term of one year. The Chair and voting CPC member may be (but are not required t
 hold annual elections to select a TSC Chairperson and voting CPC member; there are no limits on the number of terms a 
 TSC Chairperson or voting CPC member may serve.
 
-#### Section 4.2.2. Voting
+#### Section 4.2.2. Decision Making
 
 For internal project decisions, Collaborators shall operate under Lazy Consensus. The TSC voting members shall establish 
 appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods) within the 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -33,20 +33,7 @@ in modern web development, helping developers streamline their workflows and bui
   [GitHub Discussions](https://github.com/webpack/webpack/discussions)
 
 In addition to the main repository, `webpack` (bundler), the organization maintains and manages several other core 
-projects that are integral to the ecosystem such as:
-
-- **webpack-dev-server**: Provides a local server with live reloading and hot module replacement, improving developer 
-  productivity.
-- **webpack-cli**: Offers a command-line interface to interact with webpack's build processes and configurations.
-- **webpack-contrib projects**: Includes various loaders, plugins, middlewares and utility repositories such as:
-  - `sass-loader`
-  - `file-loader`
-  - `style-loader`
-  - `webpack-hot-middleware`
-  - `webpack-bundle-analyzer`
-
-These enable the handling of different asset types, interacting with webpack in various capacities to monitor builds 
-and improve applications.
+projects that are integral to the ecosystem such as `webpack-dev-server`, `webpack-cli`,  and `webpack-contrib` projects.
 
 These repositories, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib are owned by the webpack project.`.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -77,7 +77,7 @@ Responsibility for directing individual meetings may be delegated by the TSC Cha
 Minutes or an appropriate recording shall be taken and made available to the community through accessible public
 postings.
 
-TSC voting members are expected to regularly participate in TSC meetings and issue triaging. Meeting notes will be released such that absent members of the TSC can provide feedback in any way.
+TSC voting members are expected to regularly participate in TSC meetings and issue triaging.
 
 A TSC voting member is automatically converted to a TSC regular member if they do not participate in three consecutive
 TSC votes.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -96,7 +96,7 @@ within the webpack project, including:
 * Conduct guidelines.
 * Maintaining the list of additional Collaborators.
 * Development process and any coding standards.
-* Mediating technical conflicts between Collaborators or Foundation projects.
+* Mediating technical conflicts between Collaborators or `webpack` projects.
 
 The TSC voting members will define webpack project's release vehicles.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -77,7 +77,7 @@ Responsibility for directing individual meetings may be delegated by the TSC Cha
 Minutes or an appropriate recording shall be taken and made available to the community through accessible public 
 postings.
 
-TSC voting members are expected to regularly participate in TSC activities.
+TSC voting members are expected to regularly participate in TSC meetings and issue triaging. Meeting notes will be released such that absent members of the TSC can provide feedback in any way. 
 
 A TSC voting member is automatically converted to a TSC regular member if they do not participate in three consecutive 
 TSC votes.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -91,7 +91,7 @@ within the webpack project, including:
 * Release quality standards.
 * Technical direction.
 * Project governance and process.
-* GitHub repository hosting.
+* GitHub repository management.
 * Conduct guidelines.
 * Maintaining the list of additional Collaborators.
 * Development process and any coding standards.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -141,7 +141,6 @@ consensus the moderator will ask "Does anyone object?" as a final call for disse
 For all votes, a simple majority of all TSC voting members for, or against, the issue wins. A TSC voting member may 
 choose to participate in any vote through abstention. Votes are needed to add new members, remove members from the TSC or deciding in project critical issues, such as roadmapping major versions of webpack core.
 
-All changes to this charter must be approved by the CPC.
 
 ## Section 5. Definitions
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -131,14 +131,8 @@ TSC Chairperson or voting CPC member may serve.
 
 #### Section 4.2.2. Decision Making
 
-For webpack projects' decisions, Collaborators shall operate under Lazy Consensus. The TSC voting members shall establish 
-appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods) within the 
-development process.
-
-The TSC voting members follow a [Consensus Seeking][] decision making model. When an agenda item has appeared to reach a 
-consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
-
-For all votes, a simple majority of all TSC voting members for, or against, the issue wins. A TSC voting member may 
+For webpack projects' decisions, Collaborators and TSC voting members shall operate under Lazy Consensus. When an agenda item has appeared to reach a 
+consensus, the moderator will ask "Does anyone object?" as a final call for dissent from the consensus. For all votes, a simple majority of all TSC voting members for, or against, the issue wins. A TSC voting member may 
 choose to participate in any vote through abstention. Votes are needed to add new members, remove members from the TSC or deciding in project critical issues, such as roadmapping major versions of webpack core.
 
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -42,7 +42,7 @@ These repositories, along with others housed within the `github.com/webpack` and
 - Testing frameworks (e.g., unit, integration, or end-to-end testing tools)
 - API development and handling
 - Server-side rendering directly (although it can integrate with SSR frameworks)
-- Frameworks and libraries that operate in their own capacity.
+- `webpack`-related frameworks and libraries that operate in their own capacity.
 
 ## Section 2. Relationship with OpenJS Foundation CPC.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -63,7 +63,7 @@ TSC memberships are not time-limited. There is no maximum size of the TSC. The T
 members.
 
 The TSC may add additional voting members to the TSC through meeting consensus. The consensus requires at least five TSC members to be present to approve a new voting member.  A TSC member can be removed from the TSC by voluntary 
-resignation or by a standard TSC motion. A standard TSC motion can be used to change a regular TSC member to a voting 
+resignation or by consensus with at least five voting members to be present. A vote in a TSC meeting can be used to change a regular TSC member to a voting 
 TSC member, or to change a voting TSC member to a regular TSC member.
 
 No more than one-fourth of the TSC voting members may be affiliated with the same employer. If a change in TSC voting 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -150,8 +150,7 @@ All changes to this charter must be approved by the CPC.
   promoted to a Collaborator by the TSC. Contributors should rarely be blocked by the TSC and never by the CPC or 
   OpenJS Foundation Board.
 
-* **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the webpack project creation 
-  process and approved by the TSC.
+* **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the webpack organization creation.
 
 ----
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -123,11 +123,6 @@ choose to participate in any vote through abstention. Votes are needed to add ne
 
 ## Section 5. Definitions
 
-* **Contributors**: contribute code or other artifacts, but do not have the right to commit to the code base.
-  Contributors work with the project's Collaborators to have code committed to the code base. A Contributor may be
-  promoted to a Collaborator by the TSC. Contributors should rarely be blocked by the TSC and never by the CPC or
-  OpenJS Foundation Board.
-
 * **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the webpack organization creation.
 
 ----

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -2,18 +2,18 @@
 
 ## Section 0. Guiding Principle
 
-The webpack project is part of the OpenJS Foundation. The project operates transparently, openly, collaboratively, 
+The webpack project is part of the OpenJS Foundation. The project operates transparently, openly, collaboratively,
 and ethically. Project proposals, timelines, and status must not merely be open, but also easily visible to outsiders.
 
 ## Section 1. Scope
 
-The webpack project is a highly flexible and efficient module bundler for modern JavaScript applications. Its primary 
-purpose is to transform and bundle various modules (JavaScript, CSS, images, etc.) into a format suitable for web 
-applications. Webpack focuses on enhancing the developer experience, providing optimizations for production environments, 
+The webpack project is a highly flexible and efficient module bundler for modern JavaScript applications. Its primary
+purpose is to transform and bundle various modules (JavaScript, CSS, images, etc.) into a format suitable for web
+applications. Webpack focuses on enhancing the developer experience, providing optimizations for production environments,
 and enabling configurations to support a wide range of use cases and edge cases for specific projects.
 
-With this, webpack not only simplifies the process of managing application dependencies, but it also offers tools to 
-optimize performance, maintainability, and scalability. The webpack community contributes solutions to common challenges 
+With this, webpack not only simplifies the process of managing application dependencies, but it also offers tools to
+optimize performance, maintainability, and scalability. The webpack community contributes solutions to common challenges
 in modern web development, helping developers streamline their workflows and build robust applications.
 
 ### 1.1: In-scope
@@ -27,12 +27,12 @@ in modern web development, helping developers streamline their workflows and bui
 - Integrating with modern JavaScript frameworks (e.g., React, Vue, Angular)
 - Providing detailed build reports and debugging tools for development and production
 - Supporting multiple output formats (e.g., AMD, CommonJS, ES Modules) for compatibility with various environments
-- Community-driven tools and best practices provided through 
+- Community-driven tools and best practices provided through
   [plugins](https://webpack.js.org/plugins/) and [guides](https://webpack.js.org/guides/)
-- Technical help and discussions via community platforms such as 
+- Technical help and discussions via community platforms such as
   [GitHub Discussions](https://github.com/webpack/webpack/discussions)
 
-In addition to the main repository, `webpack` (bundler), the organization maintains and manages several other core 
+In addition to the main repository, `webpack` (bundler), the organization maintains and manages several other core
 projects that are integral to the ecosystem such as `webpack-dev-server`, `webpack-cli`,  and `webpack-contrib` projects.
 
 These repositories, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib are owned by the webpack project.`.
@@ -46,45 +46,45 @@ These repositories, along with others housed within the `github.com/webpack` and
 
 ## Section 2. Relationship with OpenJS Foundation CPC.
 
-Most large, complex open source communities have both a business and a technical governance model. Technical leadership 
-for the projects within the OpenJS Foundation is delegated to the projects through their project charters by the OpenJS 
-Cross Project Council (CPC). In the case of the webpack project, it is delegated to the webpack Technical Steering 
+Most large, complex open source communities have both a business and a technical governance model. Technical leadership
+for the projects within the OpenJS Foundation is delegated to the projects through their project charters by the OpenJS
+Cross Project Council (CPC). In the case of the webpack project, it is delegated to the webpack Technical Steering
 Committee ("TSC"). OpenJS Foundation's business leadership is the Board of Directors (the "Board").
 
 This charter can only be amended with the approval of the CPC.
 
 ## Section 3. Establishment of the TSC
 
-TSC members can be either _regular_ members or _voting_ members. Regular members can attend meetings and participate in 
-TSC discussions, but do not vote. Voting members can do everything regular members can do, and also have the ability to 
+TSC members can be either _regular_ members or _voting_ members. Regular members can attend meetings and participate in
+TSC discussions, but do not vote. Voting members can do everything regular members can do, and also have the ability to
 cast votes when consensus is not reached on an issue.
 
-TSC memberships are not time-limited. There is no maximum size of the TSC. The TSC must have at least four voting 
+TSC memberships are not time-limited. There is no maximum size of the TSC. The TSC must have at least four voting
 members.
 
-The TSC may add additional voting members to the TSC through meeting consensus. The consensus requires at least five TSC members to be present to approve a new voting member.  A TSC member can be removed from the TSC by voluntary 
-resignation or by consensus with at least five voting members to be present. A vote in a TSC meeting can be used to change a regular TSC member to a voting 
+The TSC may add additional voting members to the TSC through meeting consensus. The consensus requires at least five TSC members to be present to approve a new voting member.  A TSC member can be removed from the TSC by voluntary
+resignation or by consensus with at least five voting members to be present. A vote in a TSC meeting can be used to change a regular TSC member to a voting
 TSC member, or to change a voting TSC member to a regular TSC member.
 
-No more than one-fourth of the TSC voting members may be affiliated with the same employer. If a change in TSC voting 
-membership or a change of employment by a TSC voting member creates a situation where more than one-fourth of the TSC 
-voting membership shares an employer, then the situation must be immediately remedied by the removal of voting member 
+No more than one-fourth of the TSC voting members may be affiliated with the same employer. If a change in TSC voting
+membership or a change of employment by a TSC voting member creates a situation where more than one-fourth of the TSC
+voting membership shares an employer, then the situation must be immediately remedied by the removal of voting member
 status from one or more TSC voting members affiliated with the over-represented employer(s).
 
-The TSC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On 
-Air, or through any other appropriate means selected by the TSC). The meeting shall be directed by the TSC Chairperson. 
-Responsibility for directing individual meetings may be delegated by the TSC Chairperson to any other TSC voting member. 
-Minutes or an appropriate recording shall be taken and made available to the community through accessible public 
+The TSC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On
+Air, or through any other appropriate means selected by the TSC). The meeting shall be directed by the TSC Chairperson.
+Responsibility for directing individual meetings may be delegated by the TSC Chairperson to any other TSC voting member.
+Minutes or an appropriate recording shall be taken and made available to the community through accessible public
 postings.
 
-TSC voting members are expected to regularly participate in TSC meetings and issue triaging. Meeting notes will be released such that absent members of the TSC can provide feedback in any way. 
+TSC voting members are expected to regularly participate in TSC meetings and issue triaging. Meeting notes will be released such that absent members of the TSC can provide feedback in any way.
 
-A TSC voting member is automatically converted to a TSC regular member if they do not participate in three consecutive 
+A TSC voting member is automatically converted to a TSC regular member if they do not participate in three consecutive
 TSC votes.
 
 ## Section 4. Roles & Responsibilities of the TSC
 
-Subject to such policies as may be set by the CPC, the TSC voting members are responsible for all technical development 
+Subject to such policies as may be set by the CPC, the TSC voting members are responsible for all technical development
 within the webpack project, including:
 
 * Setting release dates.
@@ -101,9 +101,9 @@ The TSC voting members will define webpack project's release vehicles.
 
 ### Section 4.1. webpack Project Operations
 
-The TSC voting members will establish and maintain a development process for the webpack project. The development 
-process will establish guidelines for how the developers and community will operate. It will, for example, establish 
-appropriate timelines for TSC review (e.g. agenda items must be published at least a certain number of hours in advance 
+The TSC voting members will establish and maintain a development process for the webpack project. The development
+process will establish guidelines for how the developers and community will operate. It will, for example, establish
+appropriate timelines for TSC review (e.g. agenda items must be published at least a certain number of hours in advance
 of a TSC meeting).
 
 Note that project operations remain subject to any relevant policy or process specified by the OpenJS Foundation board or Cross Project Council.
@@ -112,35 +112,20 @@ Note that project operations remain subject to any relevant policy or process sp
 
 #### Section 4.2.1. Elections
 
-Leadership roles in the webpack project will be peer elected representatives of the community.
-
-For election of persons (such as the TSC Chairperson), a multiple-candidate method should be used, such as:
-
-* [Condorcet][] or
-* [Single Transferable Vote][]
-
-Multiple-candidate methods may be reduced to simple election by plurality when there are only two candidates for one 
-position to be filled. No election is required if there is only one candidate and no objections to the candidate's 
-election. Elections shall be done within the projects by the Collaborators active in the project.
-
-The TSC voting members will elect from amongst voting TSC members a TSC Chairperson to work on building an agenda for 
-TSC meetings and a OpenJS Cross Project Council (CPC) voting member to represent the TSC in the OpenJS Foundation for a 
-term of one year. The Chair and voting CPC member may be (but are not required to be) the same person. The TSC shall 
-hold annual elections to select a TSC Chairperson and voting CPC member; there are no limits on the number of terms a 
-TSC Chairperson or voting CPC member may serve.
+These processes are described in webpack's [GOVERNANCE](GOVERNANCE.md) document.
 
 #### Section 4.2.2. Decision Making
 
-For webpack projects' decisions, Collaborators and TSC voting members shall operate under Lazy Consensus. When an agenda item has appeared to reach a 
-consensus, the moderator will ask "Does anyone object?" as a final call for dissent from the consensus. For all votes, a simple majority of all TSC voting members for, or against, the issue wins. A TSC voting member may 
+For webpack projects' decisions, Collaborators and TSC voting members shall operate under Lazy Consensus ([consensus seeking][]). When an agenda item has appeared to reach a
+consensus, the moderator will ask "Does anyone object?" as a final call for dissent from the consensus. For all votes, a simple majority of all TSC voting members for, or against, the issue wins. A TSC voting member may
 choose to participate in any vote through abstention. Votes are needed to add new members, remove members from the TSC or deciding in project critical issues, such as roadmapping major versions of webpack core.
 
 
 ## Section 5. Definitions
 
-* **Contributors**: contribute code or other artifacts, but do not have the right to commit to the code base. 
-  Contributors work with the project's Collaborators to have code committed to the code base. A Contributor may be 
-  promoted to a Collaborator by the TSC. Contributors should rarely be blocked by the TSC and never by the CPC or 
+* **Contributors**: contribute code or other artifacts, but do not have the right to commit to the code base.
+  Contributors work with the project's Collaborators to have code committed to the code base. A Contributor may be
+  promoted to a Collaborator by the TSC. Contributors should rarely be blocked by the TSC and never by the CPC or
   OpenJS Foundation Board.
 
 * **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the webpack organization creation.
@@ -149,6 +134,4 @@ choose to participate in any vote through abstention. Votes are needed to add ne
 
 This work is a derivative of the [Node.js Project TSC Charter](https://github.com/nodejs/node/blob/main/TSC_CHARTER.md).
 
-[condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
 [consensus seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
-[single transferable vote]: https://en.wikipedia.org/wiki/Single_transferable_vote

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -166,7 +166,7 @@ well as a development process guide for Collaborators and Contributors looking t
   promoted to a Collaborator by the TSC. Contributors should rarely be blocked by the TSC and never by the CPC or 
   OpenJS Foundation Board.
 
-* **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the project creation 
+* **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the webpack project creation 
   process and approved by the TSC.
 
 ----

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -62,7 +62,7 @@ cast votes when consensus is not reached on an issue.
 TSC memberships are not time-limited. There is no maximum size of the TSC. The TSC must have at least four voting 
 members.
 
-The TSC may add additional voting members to the TSC by a standard TSC motion. A TSC member can be removed from the TSC by voluntary 
+The TSC may add additional voting members to the TSC through meeting consensus. The consensus requires at least five TSC members to be present to approve a new voting member.  A TSC member can be removed from the TSC by voluntary 
 resignation or by a standard TSC motion. A standard TSC motion can be used to change a regular TSC member to a voting 
 TSC member, or to change a voting TSC member to a regular TSC member.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -139,7 +139,7 @@ The TSC voting members follow a [Consensus Seeking][] decision making model. Whe
 consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
 
 For all votes, a simple majority of all TSC voting members for, or against, the issue wins. A TSC voting member may 
-choose to participate in any vote through abstention.
+choose to participate in any vote through abstention. Votes are needed to add new members, remove members from the TSC or deciding in project critical issues, such as roadmapping major versions of webpack core.
 
 All changes to this charter must be approved by the CPC.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -93,9 +93,9 @@ within the webpack project, including:
 * Project governance and process.
 * GitHub repository management.
 * Conduct guidelines.
-* Maintaining the list of additional Collaborators.
+* Maintaining the list of additional collaborators.
 * Development process and any coding standards.
-* Mediating technical conflicts between Collaborators or `webpack` projects.
+* Mediating technical conflicts between collaborators or `webpack` projects.
 
 The TSC voting members will define webpack project's release vehicles.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -92,7 +92,7 @@ within the webpack project, including:
 * Technical direction.
 * Project governance and process.
 * GitHub repository management.
-* Conduct guidelines.
+* Conduct and maintain guidelines defined by the OpenJS Foundation Cross Project Council.
 * Maintaining the list of additional collaborators.
 * Development process and any coding standards.
 * Mediating technical conflicts between collaborators or `webpack` projects.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -144,21 +144,6 @@ choose to participate in any vote through abstention.
 
 All changes to this charter must be approved by the CPC.
 
-#### Section 4.3. Other Project Roles
-
-The webpack git repository is maintained by the TSC and additional Collaborators who are added by the TSC voting members 
-on an ongoing basis.
-
-Individuals making significant and valuable contributions are made Collaborators and given commit-access to the project.
-These individuals are identified by the TSC and their addition as Collaborators is discussed during a TSC meeting. 
-Modifications of the contents of the git repository are made on a collaborative basis as defined in the development 
-process.
-
-Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found 
-consensus to the TSC for discussion. The TSC voting members 
-should serve as the final arbiter where required. The TSC will maintain and publish a list of current Collaborators, as 
-well as a development process guide for Collaborators and Contributors looking to participate in the development effort.
-
 ## Section 5. Definitions
 
 * **Contributors**: contribute code or other artifacts, but do not have the right to commit to the code base. 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -48,7 +48,7 @@ projects that are integral to the ecosystem such as:
 These enable the handling of different asset types, interacting with webpack in various capacities to monitor builds 
 and improve applications.
 
-These projects, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib`.
+These repositories, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib are owned by the webpack project.`.
 
 ### 1.2: Out-of-Scope
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,185 @@
+# webpack TSC Charter
+
+## Section 0. Guiding Principle
+
+The webpack project is part of the OpenJS Foundation. The project operates transparently, openly, collaboratively, 
+and ethically. Project proposals, timelines, and status must not merely be open, but also easily visible to outsiders.
+
+## Section 1. Scope
+
+The webpack project is a highly flexible and efficient module bundler for modern JavaScript applications. Its primary 
+purpose is to transform and bundle various modules (JavaScript, CSS, images, etc.) into a format suitable for web 
+applications. Webpack focuses on enhancing the developer experience, providing optimizations for production environments, 
+and enabling configurations to support a wide range of use cases and edge cases for specific projects.
+
+With this, webpack not only simplifies the process of managing application dependencies, but it also offers tools to 
+optimize performance, maintainability, and scalability. The webpack community contributes solutions to common challenges 
+in modern web development, helping developers streamline their workflows and build robust applications.
+
+### 1.1: In-scope
+
+- Bundling JavaScript files and their dependencies into a single output (or multiple outputs) for browser environments
+- Handling of asset files such as CSS, images, fonts, and other static resources
+- Optimization of assets for production, including minification, compression, and tree shaking (removal of unused code)
+- Enabling hot module replacement (HMR) for faster development feedback loops
+- Configuration and extensibility through plugins and loaders
+- Support for code splitting and lazy loading to enhance performance
+- Integrating with modern JavaScript frameworks (e.g., React, Vue, Angular)
+- Providing detailed build reports and debugging tools for development and production
+- Supporting multiple output formats (e.g., AMD, CommonJS, ES Modules) for compatibility with various environments
+- Community-driven tools and best practices provided through 
+  [plugins](https://webpack.js.org/plugins/) and [guides](https://webpack.js.org/guides/)
+- Technical help and discussions via community platforms such as 
+  [GitHub Discussions](https://github.com/webpack/webpack/discussions)
+
+In addition to the main repository, `webpack` (bundler), the organization maintains and manages several other core 
+projects that are integral to the ecosystem such as:
+
+- **webpack-dev-server**: Provides a local server with live reloading and hot module replacement, improving developer 
+  productivity.
+- **webpack-cli**: Offers a command-line interface to interact with webpack's build processes and configurations.
+- **webpack-contrib projects**: Includes various loaders, plugins, middlewares and utility repositories such as:
+  - `sass-loader`
+  - `file-loader`
+  - `style-loader`
+  - `webpack-hot-middleware`
+  - `webpack-bundle-analyzer`
+
+These enable the handling of different asset types, interacting with webpack in various capacities to monitor builds 
+and improve applications.
+
+These projects, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib`.
+
+## Section 2. Relationship with OpenJS Foundation CPC.
+
+Most large, complex open source communities have both a business and a technical governance model. Technical leadership 
+for the projects within the OpenJS Foundation is delegated to the projects through their project charters by the OpenJS 
+Cross Project Council (CPC). In the case of the webpack project, it is delegated to the webpack Technical Steering 
+Committee ("TSC"). OpenJS Foundation's business leadership is the Board of Directors (the "Board").
+
+This charter can only be amended with the approval of the CPC.
+
+## Section 3. Establishment of the TSC
+
+TSC members can be either _regular_ members or _voting_ members. Regular members can attend meetings and participate in 
+TSC discussions, but do not vote. Voting members can do everything regular members can do, and also have the ability to 
+cast votes when consensus is not reached on an issue.
+
+TSC memberships are not time-limited. There is no maximum size of the TSC. The TSC must have at least four voting 
+members.
+
+There is no specific set of requirements or qualifications for TSC membership beyond these rules. The TSC may add 
+additional voting members to the TSC by a standard TSC motion. A TSC member can be removed from the TSC by voluntary 
+resignation or by a standard TSC motion. A standard TSC motion can be used to change a regular TSC member to a voting 
+TSC member, or to change a voting TSC member to a regular TSC member.
+
+No more than one-fourth of the TSC voting members may be affiliated with the same employer. If a change in TSC voting 
+membership or a change of employment by a TSC voting member creates a situation where more than one-fourth of the TSC 
+voting membership shares an employer, then the situation must be immediately remedied by the removal of voting member 
+status from one or more TSC voting members affiliated with the over-represented employer(s).
+
+The TSC shall meet regularly using tools that enable participation by the community (e.g. weekly on a Google Hangout On 
+Air, or through any other appropriate means selected by the TSC). The meeting shall be directed by the TSC Chairperson. 
+Responsibility for directing individual meetings may be delegated by the TSC Chairperson to any other TSC voting member. 
+Minutes or an appropriate recording shall be taken and made available to the community through accessible public 
+postings.
+
+TSC voting members are expected to regularly participate in TSC activities.
+
+A TSC voting member is automatically converted to a TSC regular member if they do not participate in three consecutive 
+TSC votes.
+
+## Section 4. Roles & Responsibilities of the TSC
+
+Subject to such policies as may be set by the CPC, the TSC voting members are responsible for all technical development 
+within the webpack project, including:
+
+* Setting release dates.
+* Release quality standards.
+* Technical direction.
+* Project governance and process.
+* GitHub repository hosting.
+* Conduct guidelines.
+* Maintaining the list of additional Collaborators.
+* Development process and any coding standards.
+* Mediating technical conflicts between Collaborators or Foundation projects.
+
+The TSC voting members will define webpack project's release vehicles.
+
+### Section 4.1. webpack Project Operations
+
+The TSC voting members will establish and maintain a development process for the webpack project. The development 
+process will establish guidelines for how the developers and community will operate. It will, for example, establish 
+appropriate timelines for TSC review (e.g. agenda items must be published at least a certain number of hours in advance 
+of a TSC meeting).
+
+The TSC and entire technical community will follow any processes as may be specified by the OpenJS Foundation Board 
+relating to the intake and license compliance review of contributions, including the OpenJS Foundation IP Policy.
+
+### Section 4.2. Decision-making, Voting, and/or Elections
+
+#### Section 4.2.1. Elections
+
+Leadership roles in the webpack project will be peer elected representatives of the community.
+
+For election of persons (such as the TSC Chairperson), a multiple-candidate method should be used, such as:
+
+* [Condorcet][] or
+* [Single Transferable Vote][]
+
+Multiple-candidate methods may be reduced to simple election by plurality when there are only two candidates for one 
+position to be filled. No election is required if there is only one candidate and no objections to the candidate's 
+election. Elections shall be done within the projects by the Collaborators active in the project.
+
+The TSC voting members will elect from amongst voting TSC members a TSC Chairperson to work on building an agenda for 
+TSC meetings and a OpenJS Cross Project Council (CPC) voting member to represent the TSC in the OpenJS Foundation for a 
+term of one year. The Chair and voting CPC member may be (but are not required to be) the same person. The TSC shall 
+hold annual elections to select a TSC Chairperson and voting CPC member; there are no limits on the number of terms a 
+TSC Chairperson or voting CPC member may serve.
+
+#### Section 4.2.2. Voting
+
+For internal project decisions, Collaborators shall operate under Lazy Consensus. The TSC voting members shall establish 
+appropriate guidelines for implementing Lazy Consensus (e.g. expected notification and review time periods) within the 
+development process.
+
+The TSC voting members follow a [Consensus Seeking][] decision making model. When an agenda item has appeared to reach a 
+consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
+
+For all votes, a simple majority of all TSC voting members for, or against, the issue wins. A TSC voting member may 
+choose to participate in any vote through abstention.
+
+All changes to this charter must be approved by the CPC.
+
+#### Section 4.2.3. Project Roles
+
+The webpack git repository is maintained by the TSC and additional Collaborators who are added by the TSC voting members 
+on an ongoing basis.
+
+Individuals making significant and valuable contributions are made Collaborators and given commit-access to the project.
+These individuals are identified by the TSC and their addition as Collaborators is discussed during a TSC meeting. 
+Modifications of the contents of the git repository are made on a collaborative basis as defined in the development 
+process.
+
+Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found 
+consensus to the TSC for discussion by assigning the `tsc-agenda` tag to a pull request or issue. The TSC voting members 
+should serve as the final arbiter where required. The TSC will maintain and publish a list of current Collaborators, as 
+well as a development process guide for Collaborators and Contributors looking to participate in the development effort.
+
+## Section 5. Definitions
+
+* **Contributors**: contribute code or other artifacts, but do not have the right to commit to the code base. 
+  Contributors work with the project's Collaborators to have code committed to the code base. A Contributor may be 
+  promoted to a Collaborator by the TSC. Contributors should rarely be encumbered by the TSC and never by the CPC or 
+  OpenJS Foundation Board.
+
+* **Project**: a technical collaboration effort, e.g. a subsystem, that is organized through the project creation 
+  process and approved by the TSC.
+
+----
+
+This work is a derivative of the [Node.js Project TSC Charter](https://github.com/nodejs/node/blob/main/TSC_CHARTER.md).
+
+[condorcet]: https://en.wikipedia.org/wiki/Condorcet_method
+[consensus seeking]: https://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[single transferable vote]: https://en.wikipedia.org/wiki/Single_transferable_vote

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -35,7 +35,7 @@ in modern web development, helping developers streamline their workflows and bui
 In addition to the main repository, `webpack` (bundler), the organization maintains and manages several other core
 projects that are integral to the ecosystem such as `webpack-dev-server`, `webpack-cli`,  and `webpack-contrib` projects.
 
-These repositories, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib are owned by the webpack project.`.
+These repositories, along with others housed within the `github.com/webpack` and `github.com/webpack-contrib` are owned by the webpack project.
 
 ### 1.2: Out-of-Scope
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -106,8 +106,7 @@ process will establish guidelines for how the developers and community will oper
 appropriate timelines for TSC review (e.g. agenda items must be published at least a certain number of hours in advance 
 of a TSC meeting).
 
-The TSC and entire technical community will follow any processes as may be specified by the OpenJS Foundation Board 
-relating to the intake and license compliance review of contributions, including the OpenJS Foundation IP Policy.
+Note that project operations remain subject to any relevant policy or process specified by the OpenJS Foundation board or Cross Project Council.
 
 ### Section 4.2. Decision-making, Voting, and/or Elections
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -39,9 +39,9 @@ These repositories, along with others housed within the `github.com/webpack` and
 
 ### 1.2: Out-of-Scope
 
-- Testing frameworks (e.g., unit, integration, or end-to-end testing tools)
-- API development and handling
-- Server-side rendering directly (although it can integrate with SSR frameworks)
+- Testing frameworks (e.g., unit, integration, or end-to-end testing tools).
+- APIs and tools that uses webpack in any way and are not in the webpack organization.
+- Server-side rendering directly (although it can integrate with SSR frameworks).
 - `webpack`-related frameworks and libraries that operate in their own capacity.
 
 ## Section 2. Relationship with OpenJS Foundation CPC.
@@ -62,8 +62,7 @@ cast votes when consensus is not reached on an issue.
 TSC memberships are not time-limited. There is no maximum size of the TSC. The TSC must have at least four voting 
 members.
 
-There is no specific set of requirements or qualifications for TSC membership beyond these rules. The TSC may add 
-additional voting members to the TSC by a standard TSC motion. A TSC member can be removed from the TSC by voluntary 
+The TSC may add additional voting members to the TSC by a standard TSC motion. A TSC member can be removed from the TSC by voluntary 
 resignation or by a standard TSC motion. A standard TSC motion can be used to change a regular TSC member to a voting 
 TSC member, or to change a voting TSC member to a regular TSC member.
 


### PR DESCRIPTION
This PR effectively adopts (and replaces) the current governance model of `webpack` with the new governance model, pending approval from the CPC (Cross Project Council) from the OpenJS Foundation.

This proposal was crafted together with the Cross Project Council and current maintainers of webpack.

### This PR:

- Adds the CHARTER.md file

cc @webpack/core-team cc @webpack/tsc