### PR TITLE
Remove H1 heading from MODERATION_POLICY.md

### DIFF
--- a/MODERATION_POLICY.md
+++ b/MODERATION_POLICY.md
@@ -1,4 +1,3 @@
-# Moderation policy
 
 If you are not a member of the webpack GitHub Organization and wish to submit a
 moderation request, please see [Requesting Moderation][]


### PR DESCRIPTION
## Issue

The `/contribute/Governance-moderation-policy/` page was rendering the
title "Moderation Policy" twice - once from the `<h1>` injected by
`Page.jsx` using the frontmatter `title` field, and once from the
`# Moderation policy` heading embedded in the MDX content body.

## Fix

- Removed the `# Moderation policy` H1 from the MDX content body so the
  heading is only rendered once (by `Page.jsx`).


## Root Cause

`Page.jsx` always renders `<h1>{title}</h1>` from the page frontmatter.
Other pages in the `contribute/` section (e.g. `Governance-member-expectations.mdx`)
do not include an H1 in their content, so they are unaffected.
This page was an exception that included a duplicate heading in the MDX body.

## Images Attached (Before and After)
<img width="940" height="191" alt="image" src="https://github.com/user-attachments/assets/5eec6558-6570-45b2-9411-b94dcac50b15" />
<img width="999" height="169" alt="image" src="https://github.com/user-attachments/assets/80d601a8-ede7-4c10-814e-345829d63a95" />
